### PR TITLE
Fix issue resulting in 1 byte files for "Save Plugin as Folder"

### DIFF
--- a/ServerSide.js
+++ b/ServerSide.js
@@ -158,12 +158,13 @@ ServerSide.loadWiki = function (wikiName, wikiFolder) {
       if (!$tw.Bob.Wikis[wikiName].wiki.getTiddler('$:/core')) {
         $tw.Bob.Wikis[wikiName].wiki.addTiddler($tw.loadPluginFolder($tw.boot.corePath));
       }
+      // Add tiddlers to the wiki
+      var wikiInfo = ServerSide.loadWikiTiddlers(fullPath, {prefix: wikiName});
       $tw.Bob.Wikis[wikiName].wiki.registerPluginTiddlers("plugin",$tw.safeMode ? ["$:/core"] : undefined);
       // Unpack plugin tiddlers
   	  $tw.Bob.Wikis[wikiName].wiki.readPluginInfo();
       $tw.Bob.Wikis[wikiName].wiki.unpackPluginTiddlers();
-      // Add tiddlers to the wiki
-      var wikiInfo = ServerSide.loadWikiTiddlers(fullPath, {prefix: wikiName});
+      
 
       // Add plugins, themes and languages
       ServerSide.loadPlugins(wikiInfo.plugins,$tw.config.pluginsPath,$tw.config.pluginsEnvVar, wikiName);


### PR DESCRIPTION
What was happening.  When attempting to save a plugin as a folder, non-updated shadow tiddlers would render as 1 byte files.  

Why: The shadow tiddler was not present in the wiki object on the server side.
Why: The plugin tiddler was never unpacked.
Why: In ServerSide.js non $:/core tiddlers are added to the wiki object after the call to `.registerPluginTiddlers`.

Fix: Move `.loadWikiTiddlers` before the call to `.registerPluginTiddlers`.