### PR TITLE
Fix "TypeError: Assignment to constant variable.

### DIFF
--- a/WebSockets/WebsocketAdaptor.js
+++ b/WebSockets/WebsocketAdaptor.js
@@ -105,7 +105,7 @@ if($tw.node) {
         if(filepath.substr(-extension.length).toLocaleLowerCase() !== extension.toLocaleLowerCase()) {
           filepath = filepath + extension;
         }
-        const filename = path.basename(filepath)
+        let filename = path.basename(filepath)
         let count = 1;
         // Add a discriminator if we're clashing with an existing filename while
         // handling case-insensitive filesystems (NTFS, FAT/FAT32, etc.)


### PR DESCRIPTION
Auto incrementing the file name suffix (aka "discriminator") doesn't work if the file name is a constant; it just crashes out of node with a "TypeError" (actually should be a storage class or mutability error, but that's javascript for you).

Making it mutable fixes the problem.
