### PR TITLE
Add missing "username" and "password" ws-server parameters to doc

### DIFF
--- a/Configuration.md
+++ b/Configuration.md
@@ -44,6 +44,8 @@ used. If the json isn't formatted correctly than default values will be used.
   "ws-server": {
     "port": 8080,
     "host": "127.0.0.1",
+    "username": "admin",
+    "password": "p4ssw0rd",
     "autoIncrementPort": "false",
     "servePlugin": "true",
     "pathprefix": "",


### PR DESCRIPTION
See: https://github.com/OokTech/TW5-Bob/blob/6434efd0ed413ed9bb7c897bab1178d70e98da19/commands/ws-server.js#L377-L378

It could also be written in the documentation that specifying this applies not only to the ws-server, but to full Bob access.