### PR TITLE
Fixes "crashes on fetch list of media" (#180)

### DIFF
--- a/WebSockets/NodeServerHandlers.js
+++ b/WebSockets/NodeServerHandlers.js
@@ -995,6 +995,7 @@ if($tw.node) {
     $tw.Bob.Shared.sendAck(data);
 
     function thisCallback(prefix, filteredItems, urlPath) {
+      const path = require('path');
       data.tiddler = data.tiddler || path.join('$:/state/fileList/', data.wiki, $tw.settings.fileURLPrefix, urlPath);
       data.field = data.field || 'list';
 


### PR DESCRIPTION
I encountered the same problem as described in issue OokTech#180. The server crashed, displaying "ReferenceError: path is not defined." This simple patch fixed the problem.
